### PR TITLE
Fixed flag for Europa series E/E notes

### DIFF
--- a/lib/EBT2.pm
+++ b/lib/EBT2.pm
@@ -488,7 +488,7 @@ EOF
         $@ and die "eval failed: $@\n";
         goto &$field;
 
-    } elsif ($field eq 'printers') {
+    } elsif ($field eq 'printers' || $field eq 'series_countries') {
         ## close over %config - the quoted eval doesn't do it, resulting in 'Variable "%config" is not available'
         %config if 0;
 

--- a/lib/EBT2/Stats.pm
+++ b/lib/EBT2/Stats.pm
@@ -694,7 +694,7 @@ sub missing_combs_and_history {
                 push @history, {
                     index   => ++$hist_idx,
                     pname   => (split /,/, EBT2->printers ($p, $note->[SERIES]))[0],
-                    cname   => EBT2->countries ($c),
+                    cname   => EBT2->series_countries ($c, $note->[SERIES]),
                     series  => $ser,
                     pc      => $p,
                     cc      => $c,

--- a/lib/EBTST/Main.pm
+++ b/lib/EBTST/Main.pm
@@ -1501,7 +1501,7 @@ sub bad_notes {
             %$bn,
             idx        => ++$idx,
             pc_img     => $pc_iso3166,
-            cc_img     => EBT2->countries ($cc, $bn->{'series'}),
+            cc_img     => EBT2->series_countries ($cc, $bn->{'series'}),
             bbflag_pc  => EBT2->flag ($pc_iso3166),
             bbflag_cc  => EBT2->flag (EBT2->series_countries ($cc, $bn->{'series'})),
             bbflag_got => EBT2->flag ($bn->{'country'}),

--- a/lib/EBTST/Main.pm
+++ b/lib/EBTST/Main.pm
@@ -983,7 +983,7 @@ sub huge_table {
         $ht->{$sp}{'values'} = $ht_data->{$sp};
         foreach my $value (keys %{ $ht->{$sp}{'values'} }) {
             foreach my $serial (keys %{ $ht->{$sp}{'values'}{$value} }) {
-                $ht->{$sp}{'values'}{$value}{$serial}{'flag'} = EBT2->countries (substr $serial, 0, 1);
+                $ht->{$sp}{'values'}{$value}{$serial}{'flag'} = EBT2->series_countries ((substr $serial, 0, 1), $series);
             }
         }
         $ht->{$sp}{'plate_flag'} = (split /,/, EBT2->printers ((substr $plate, 0, 1), $series))[0];
@@ -1036,8 +1036,8 @@ sub short_codes {
                 $tmp->{$what} = {
                     pc_img  => $pc_iso3166,
                     pc_flag => EBT2->flag ($pc_iso3166),
-                    cc_img  => EBT2->countries ($cc),
-                    cc_flag => EBT2->flag (EBT2->countries ($cc)),
+                    cc_img  => EBT2->series_countries ($cc, $records->{$what}{'series'}),
+                    cc_flag => EBT2->flag (EBT2->series_countries ($cc, $records->{$what}{'series'})),
                     pc_str  => $pc_str,
                     cc_str  => $cc_str,
                     id      => $records->{$what}{'id'},
@@ -1376,7 +1376,7 @@ sub combs_bingo {
         if (!exists $missing->{"$p$c"}) {
             $missing->{"$p$c"} = {
                 pname   => do { local $ENV{'EBT_LANG'} = 'en'; (split /,/, EBT2->printers ($p, $ser))[0] },
-                cname   => do { local $ENV{'EBT_LANG'} = 'en'; EBT2->countries ($c) },
+                cname   => do { local $ENV{'EBT_LANG'} = 'en'; EBT2->series_countries ($c, $ser) },
                 pletter => $p,
                 cletter => $c,
                 values  => [ $v ],
@@ -1395,7 +1395,7 @@ sub combs_bingo {
             index        => ++$hpc_idx,
             ## this history ends up in the BBCode, let's assign its flags
             pc_flag      => EBT2->flag ((split /,/, EBT2->printers  ($h->{'pc'}, $h->{'series'}))[0]),
-            cc_flag      => EBT2->flag (EBT2->countries ($h->{'cc'})),
+            cc_flag      => EBT2->flag (EBT2->series_countries ($h->{'cc'}, $h->{'series'})),
             country_flag => EBT2->flag ($h->{'country'}),
         }
     }
@@ -1501,9 +1501,9 @@ sub bad_notes {
             %$bn,
             idx        => ++$idx,
             pc_img     => $pc_iso3166,
-            cc_img     => EBT2->countries ($cc),
+            cc_img     => EBT2->countries ($cc, $bn->{'series'}),
             bbflag_pc  => EBT2->flag ($pc_iso3166),
-            bbflag_cc  => EBT2->flag (EBT2->countries ($cc)),
+            bbflag_cc  => EBT2->flag (EBT2->series_countries ($cc, $bn->{'series'})),
             bbflag_got => EBT2->flag ($bn->{'country'}),
         };
     }

--- a/sample-config/ebt2.cfg
+++ b/sample-config/ebt2.cfg
@@ -6,6 +6,7 @@
     2017 = europa
 </year_to_series>
 
+#Deprecated
 <countries>
     D = ee
     E = sk
@@ -16,16 +17,54 @@
     M = pt
     N = at
     P = nl
-    R = de
     S = it
     T = ie
     U = fr
     V = es
-    W = de
     X = de
     Y = gr
     Z = be
 </countries>
+
+<series_countries>
+    <2002>
+        D = ee
+        E = sk
+        F = mt
+        G = cy
+        H = si
+        L = fi
+        M = pt
+        N = at
+        P = nl
+        S = it
+        T = ie
+        U = fr
+        V = es
+        X = de
+        Y = gr
+        Z = be
+    </2002>
+    <europa>
+        #D = pl
+        E = fr
+        #H = uk
+        #J = uk
+        M = pt
+        N = at
+        P = nl
+        R = de
+        S = it
+        T = ie
+        U = fr
+        V = es
+        W = de
+        X = de
+        Y = gr
+        Z = be
+    </europa>
+</series_countries>
+
 <printers>
     <2002>
         D = fi,Setec Oy


### PR DESCRIPTION
This fixes the flag for Europa E/E notes shown in the huge table, short codes, combinations and bad notes pages. 

R and W rows are also removed from the Countries page.

To implement this without breaking unrelated code, I have added to the ebt2.cfg file the `series_countries` enumeration, which takes into account the different series. Other existing code can still reference the old `countries` enumeration without issues.